### PR TITLE
Rename plugin identifiers

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -2,16 +2,16 @@ import { App, Editor, MarkdownView, Modal, Notice, Plugin, PluginSettingTab, Set
 
 // Remember to rename these classes and interfaces!
 
-interface MyPluginSettings {
+interface QuickCalloutSettings {
 	mySetting: string;
 }
 
-const DEFAULT_SETTINGS: MyPluginSettings = {
+const DEFAULT_SETTINGS: QuickCalloutSettings = {
 	mySetting: 'default'
 }
 
-export default class MyPlugin extends Plugin {
-	settings: MyPluginSettings;
+export default class QuickCalloutPlugin extends Plugin {
+    settings: QuickCalloutSettings;
 
 	async onload() {
 		await this.loadSettings();
@@ -108,9 +108,9 @@ class SampleModal extends Modal {
 }
 
 class SampleSettingTab extends PluginSettingTab {
-	plugin: MyPlugin;
+    plugin: QuickCalloutPlugin;
 
-	constructor(app: App, plugin: MyPlugin) {
+    constructor(app: App, plugin: QuickCalloutPlugin) {
 		super(app, plugin);
 		this.plugin = plugin;
 	}

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
-	"id": "sample-plugin",
-	"name": "Sample Plugin",
+    "id": "obsidian-quick-callout",
+    "name": "Quick Callout",
 	"version": "1.0.0",
 	"minAppVersion": "0.15.0",
-	"description": "Demonstrates some of the capabilities of the Obsidian API.",
+    "description": "Obsidian plugin to quickly format highlighted text as a callout.",
 	"author": "Obsidian",
 	"authorUrl": "https://obsidian.md",
 	"fundingUrl": "https://obsidian.md/pricing",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-	"name": "obsidian-sample-plugin",
+    "name": "obsidian-quick-callout",
 	"version": "1.0.0",
-	"description": "This is a sample plugin for Obsidian (https://obsidian.md)",
+    "description": "Obsidian plugin to quickly format highlighted text as a callout",
 	"main": "main.js",
 	"scripts": {
 		"dev": "node esbuild.config.mjs",


### PR DESCRIPTION
## Summary
- change manifest ID and name to `obsidian-quick-callout`
- rename plugin class and setting interface in `main.ts`
- update `package.json` metadata

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688b607c39608326b02e1d62cbe15bf9